### PR TITLE
Refactoring Hermes Implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com</groupId>
 	<artifactId>hermes</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
 	<name>Hermes</name>
 	<description>Mediator implementation for Java</description>
 

--- a/src/main/java/com/hermes/Hermes.java
+++ b/src/main/java/com/hermes/Hermes.java
@@ -33,16 +33,12 @@ public class Hermes implements IHermes {
         return handler.handle(message);
     }
 
-    private boolean doesItHandleMessage(IMessageHandler requestHandler, Object message) {
-        try {
-            Method handleMethod = requestHandler.getClass().getDeclaredMethod("handle", Object.class);
-            return doesItReceivesMessageTypeAsParameter(handleMethod, message);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e.getCause());
-        }
+    private boolean doesItHandleMessage(IMessageHandler requestHandler, IMessage message) {
+        return Arrays.stream(requestHandler.getClass().getDeclaredMethods())
+                .anyMatch(method -> doesItReceivesMessageTypeAsParameter(method, message));
     }
 
-    private boolean doesItReceivesMessageTypeAsParameter(Method method, Object message) {
+    private boolean doesItReceivesMessageTypeAsParameter(Method method, IMessage message) {
         return Arrays.stream(method.getParameterTypes())
                 .anyMatch(parameterType -> parameterType.equals(message.getClass()));
     }


### PR DESCRIPTION
- Refactoring of `doesItHandleMessage` signature to receive parameter of type `IMessage` instead of `Object`, and internal implementation.
- Refactoring of `doesItReceivesMessageTypeAsParameter` signature to  receive parameter of type `IMessage` instead of `Object`.
- Update version.